### PR TITLE
Fix the doc for data-disabled property as not available

### DIFF
--- a/pages/03.configuration/03.data-attributes/docs.md
+++ b/pages/03.configuration/03.data-attributes/docs.md
@@ -14,6 +14,8 @@ It is recommended that you declare your configuration options by [passing in an 
 </select>
 ```
 
+>>> Some options are not supported as `data-*`, for example `disabled` as it's not a Javascript option, but it's an HTML [attribute](/configuration/options-api).
+
 ## Nested (subkey) options
 
 Sometimes, you have options that are nested under a top-level option.  For example, the options under the `ajax` option:


### PR DESCRIPTION
This issue Fixes#https://github.com/select2/select2/issues/5497

This fix adds an `info` for the `disabled` property is not available.
Verified locally by loading the docs via Grav.